### PR TITLE
Use GitHub API per_page parameter

### DIFF
--- a/configurator/src/app/services/api.service.spec.ts
+++ b/configurator/src/app/services/api.service.spec.ts
@@ -70,7 +70,7 @@ describe('ApiService', () => {
 
       if (eTag) {
         expect(httpClientMock.get).toHaveBeenCalledWith(
-          `${baseUrl}/user/repos?type=all`,
+          `${baseUrl}/user/repos?type=all&per_page=100`,
           jasmine.objectContaining({ observe: 'response', headers: eTag ? { 'If-None-Match': eTag } : {} })
         );
       }

--- a/configurator/src/app/services/api.service.ts
+++ b/configurator/src/app/services/api.service.ts
@@ -103,7 +103,7 @@ export class ApiService {
   listRepos(): Observable<Repository[]> {
     const headers = ApiService.getDefaultHeaders(this.repositoriesEtag);
 
-    return this._http.get<Repository[]>(`${baseUrl}/user/repos?type=all`, {observe: 'response', headers})
+    return this._http.get<Repository[]>(`${baseUrl}/user/repos?type=all&per_page=100`, { observe: 'response', headers })
       .pipe(map(res => {
         // per https://docs.github.com/en/rest/guides/getting-started-with-the-rest-api#conditional-requests
         // save ETag and list of repositories


### PR DESCRIPTION
If a user has access to many repositories only the first 30 are shown in the "Select the repository and the branch to work on" modal, possibly hiding the repository the user wants to use

Steps to Reproduce:
1. Have access to more than 30 repos on the GitHub account
2. Access the testing configurator and login with the GitHub account
3. Open the repository choice dropdown
5. Only 30 repos are shown 

I see from dev tools that the `/user/repos` Github API route is used with onyl the parameter type=all. [The documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-the-authenticated-user) also cites a "per_page" parameter described with 

> integer
>The number of results per page (max 100).
>Default: 30

This change adds the parameter per_page with value 100